### PR TITLE
Search assets from library manifests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk: oraclejdk8
 env:
   matrix: # split into multiple Travis builds:
     - APIs=16,17,18,19,21 # 20 isn't supported
-    - APIs=22,23,24,25,26
+    - APIs=22,23,24,25,26,27
   global:
     - MALLOC_ARENA_MAX=2 # reduce memory usage, maybe avoid some exit 137's?
     - secure: "AnsdYjHIvtLXrDMJmlf5FJhXJOW+aLSvsyXcGFLKse6EcwTSw8XnE4bGv2eSi2YWIwoHHCStIQbI0J02rkmUu9Z5oChxhOyGtCd8U4l1XciH2U7vJOJ/i9Auw5WgLM6x8HxgH6myhNrA9xrB4fcH+8WsDMf+qLqgvJQQjqQZQGM="
@@ -17,7 +17,7 @@ android:
     - platform-tools
     - build-tools-23.0.3
     - android-23
-    - android-26
+    - android-27
     - extra-google-m2repository
     - extra-android-m2repository
     - addon-google_apis-google-23

--- a/buildSrc/src/main/groovy/AndroidSdk.groovy
+++ b/buildSrc/src/main/groovy/AndroidSdk.groovy
@@ -9,10 +9,11 @@ class AndroidSdk implements Comparable<AndroidSdk> {
     static final N = new AndroidSdk(24, "7.0.0_r1", 0)
     static final N_MR1 = new AndroidSdk(25, "7.1.0_r7", 0)
     static final O = new AndroidSdk(26, "8.0.0_r4", 0)
+    static final O_MR1 = new AndroidSdk(27, "8.1.0", 4402310)
 
     static final List<AndroidSdk> ALL_SDKS = [
             JELLY_BEAN, JELLY_BEAN_MR1, JELLY_BEAN_MR2, KITKAT,
-            LOLLIPOP, LOLLIPOP_MR1, M, N, N_MR1, O
+            LOLLIPOP, LOLLIPOP_MR1, M, N, N_MR1, O, O_MR1
     ]
 
     static final MAX_SDK = Collections.max(ALL_SDKS)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-thisVersion=3.5.1
+thisVersion=3.5.1-uber
 
 apiCompatVersion=3.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-thisVersion=3.5.1-SNAPSHOT
+thisVersion=3.5.1
 
-apiCompatVersion=3.4
+apiCompatVersion=3.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-thisVersion=3.5
+thisVersion=3.5.1-SNAPSHOT
 
 apiCompatVersion=3.4

--- a/integration_tests/dependency-on-stubs/build.gradle
+++ b/integration_tests/dependency-on-stubs/build.gradle
@@ -9,7 +9,7 @@ apply plugin: RoboJavaModulePlugin
 dependencies {
     compile project(":robolectric")
     compile "junit:junit:4.12"
-    testCompile "com.google.android:android-stubs:26"
+    testCompile "com.google.android:android-stubs:27"
 
     // Testing dependencies
     testCompile "org.assertj:assertj-core:3.8.0"

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile project(":shadows:framework")
 
     // Compile dependencies
-    compile "org.bouncycastle:bcprov-jdk15on:1.58"
+    compile "org.bouncycastle:bcprov-jdk15on:1.52"
     compile "com.thoughtworks.xstream:xstream:1.4.8"
     compileOnly "com.google.code.findbugs:jsr305:3.0.1"
 

--- a/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
@@ -43,11 +43,11 @@ public class BuckManifestFactory implements ManifestFactory {
       libraries = new ArrayList<>();
 
       for (FsFile buckResource: buckResources) {
-        libraries.add(new ManifestIdentifier(null, null, buckResource, null, null));
+        libraries.add(new ManifestIdentifier((String) null, null, buckResource, null, null));
       }
 
       for (FsFile buckAsset: buckAssets) {
-        libraries.add(new ManifestIdentifier(null, null, null, buckAsset, null));
+        libraries.add(new ManifestIdentifier((String) null, null, null, buckAsset, null));
       }
     }
 

--- a/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
@@ -42,12 +42,12 @@ public class BuckManifestFactory implements ManifestFactory {
     } else {
       libraries = new ArrayList<>();
 
-      for (FsFile buckResource: buckResources) {
-        libraries.add(new ManifestIdentifier((String) null, null, buckResource, null, null));
+      for (int i = 0; i < buckResources.size() - 1; i++) {
+        libraries.add(new ManifestIdentifier((String) null, null, buckResources.get(i), null, null));
       }
 
-      for (FsFile buckAsset: buckAssets) {
-        libraries.add(new ManifestIdentifier((String) null, null, null, buckAsset, null));
+      for (int i = 0; i < buckAssets.size() - 1; i++) {
+        libraries.add(new ManifestIdentifier(null, null, null, buckAssets.get(i), null));
       }
     }
 

--- a/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
@@ -33,28 +33,21 @@ public class BuckManifestFactory implements ManifestFactory {
 
     final List<FsFile> buckResources = getDirectoriesFromProperty(buckResDirs);
     final List<FsFile> buckAssets = getDirectoriesFromProperty(buckAssetsDirs);
-
-    if (buckResources.size() != buckAssets.size()) {
-      throw new IllegalArgumentException("number of resources and assets do not match match: "
-          + buckResources.size() + " != " + buckAssets.size());
-    }
-
-    int pathCount = buckResources.size();
-    final FsFile resDir;
-    final FsFile assetsDir;
+    final FsFile resDir = buckResources.size() == 0 ? null : buckResources.get(buckResources.size() - 1);
+    final FsFile assetsDir = buckAssets.size() == 0 ? null : buckAssets.get(buckAssets.size() - 1);
     final List<ManifestIdentifier> libraries;
-    if (pathCount == 0) {
-      resDir = null;
-      assetsDir = null;
+
+    if (resDir == null && assetsDir == null) {
       libraries = null;
     } else {
-      resDir = buckResources.get(pathCount - 1);
-      assetsDir = buckAssets.get(pathCount - 1);
       libraries = new ArrayList<>();
 
-      for (int i = 0; i < pathCount - 1; i++) {
-        libraries.add(new ManifestIdentifier(null, null,
-            buckResources.get(i), buckAssets.get(i), null));
+      for (FsFile buckResource: buckResources) {
+        libraries.add(new ManifestIdentifier(null, null, buckResource, null, null));
+      }
+
+      for (FsFile buckAsset: buckAssets) {
+        libraries.add(new ManifestIdentifier(null, null, null, buckAsset, null));
       }
     }
 

--- a/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
@@ -26,6 +26,7 @@ public class SdkConfig implements Comparable<SdkConfig> {
       addSdk(Build.VERSION_CODES.N, "7.0.0_r1", "0", "1.8", "REL");
       addSdk(Build.VERSION_CODES.N_MR1, "7.1.0_r7", "0", "1.8", "REL");
       addSdk(Build.VERSION_CODES.O, "8.0.0_r4", "0", "1.8", "REL");
+      addSdk(Build.VERSION_CODES.O_MR1, "8.1.0", "4402310", "1.8", "OMR1");
     }
 
     private void addSdk(int sdkVersion, String androidVersion, String frameworkSdkBuildVersion, String minJdkVersion, String codeName) {

--- a/robolectric/src/test/java/org/robolectric/internal/BuckManifestFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/BuckManifestFactoryTest.java
@@ -62,10 +62,11 @@ public class BuckManifestFactoryTest {
             .isEqualTo(FileFsFile.from("buck/assets2"));
 
     List<ResourcePath> resourcePathList = manifest.getIncludedResourcePaths();
-    assertThat(resourcePathList.size()).isEqualTo(2);
+    assertThat(resourcePathList.size()).isEqualTo(3);
     assertThat(resourcePathList).containsExactly(
-            new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets2")),
-            new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), FileFsFile.from("buck/assets1"))
+      new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets2")),
+      new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), null),
+      new ResourcePath(manifest.getRClass(), null, FileFsFile.from("buck/assets1"))
     );
   }
 
@@ -88,10 +89,11 @@ public class BuckManifestFactoryTest {
         .isEqualTo(FileFsFile.from("buck/assets2"));
 
     List<ResourcePath> resourcePathList = manifest.getIncludedResourcePaths();
-    assertThat(resourcePathList.size()).isEqualTo(2);
+    assertThat(resourcePathList.size()).isEqualTo(3);
     assertThat(resourcePathList).containsExactly(
-        new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets2")),
-        new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), FileFsFile.from("buck/assets1"))
+            new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets2")),
+            new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), null),
+            new ResourcePath(manifest.getRClass(), null, FileFsFile.from("buck/assets1"))
     );
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedMemoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedMemoryTest.java
@@ -1,0 +1,39 @@
+package org.robolectric.shadows;
+
+    import static org.assertj.core.api.Assertions.assertThat;
+
+    import android.os.Build;
+    import android.os.SharedMemory;
+    import org.junit.Test;
+    import org.junit.runner.RunWith;
+    import org.robolectric.RobolectricTestRunner;
+    import org.robolectric.annotation.Config;
+
+/**
+ * Unit tests for {@link ShadowSharedMemory}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ShadowSharedMemoryTest {
+
+  @Test
+  @Config(minSdk = Build.VERSION_CODES.O_MR1)
+  public void create() throws Exception {
+    SharedMemory sharedMemory = SharedMemory.create("foo", 4);
+    assertThat(sharedMemory).isNotNull();
+  }
+
+  @Test
+  @Config(minSdk = Build.VERSION_CODES.O_MR1)
+  public void size() throws Exception {
+    SharedMemory sharedMemory = SharedMemory.create("foo", 4);
+    assertThat(sharedMemory.getSize()).isEqualTo(4);
+  }
+
+  @Test
+  @Config(minSdk = Build.VERSION_CODES.O_MR1)
+  public void mapReadWrite() throws Exception {
+    SharedMemory sharedMemory = SharedMemory.create("foo", 4);
+    assertThat(sharedMemory.mapReadWrite()).isNotNull();
+  }
+}
+

--- a/scripts/install-android-prebuilt.sh
+++ b/scripts/install-android-prebuilt.sh
@@ -1,0 +1,94 @@
+@@ -0,0 1,85 @@
+#!/bin/bash
+#
+# This script signs already built AOSP Android jars, and installs them in your local
+# Maven repository. See: http://source.android.com/source/building.html for
+# more information on building AOSP.
+#
+# Usage:
+#   build-android-prebuilt.sh <jar directory path> <android version> <robolectric version>
+#
+
+set -ex
+
+function usage() {
+    echo "Usage: ${0} <jar dir path> <android-version> <robolectric-sub-version>"
+}
+
+if [[ $# -ne 3 ]]; then
+    usage
+    exit 1
+fi
+
+if [[ -z "${SIGNING_PASSWORD}" ]]; then
+    echo "Please set the GPG passphrase as SIGNING_PASSWORD"
+    exit 1
+fi
+
+JAR_DIR=$1
+ANDROID_VERSION=$2
+ROBOLECTRIC_SUB_VERSION=$3
+
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd)
+
+ROBOLECTRIC_VERSION=${ANDROID_VERSION}-robolectric-${ROBOLECTRIC_SUB_VERSION}
+
+# Final artifact names
+ANDROID_ALL=android-all-${ROBOLECTRIC_VERSION}.jar
+ANDROID_ALL_POM=android-all-${ROBOLECTRIC_VERSION}.pom
+ANDROID_ALL_SRC=android-all-${ROBOLECTRIC_VERSION}-sources.jar
+ANDROID_ALL_DOC=android-all-${ROBOLECTRIC_VERSION}-javadoc.jar
+ANDROID_BUNDLE=android-all-${ROBOLECTRIC_VERSION}-bundle.jar
+
+generate_empty_src_javadoc() {
+    TMP=`mktemp --directory`
+    cd ${TMP}
+    jar cf ${JAR_DIR}/${ANDROID_ALL_DOC} .
+    jar cf ${JAR_DIR}/${ANDROID_ALL_SRC} .
+    cd ${JAR_DIR}; rm -rf ${TMP}
+}
+
+build_signed_packages() {
+    echo "Robolectric: Building android-all.pom..."
+    sed s/VERSION/${ROBOLECTRIC_VERSION}/ ${SCRIPT_DIR}/pom_template.xml | sed s/ARTIFACT_ID/android-all/ > ${JAR_DIR}/${ANDROID_ALL_POM}
+
+    echo "Robolectric: Signing files with gpg..."
+    for ext in ".jar" "-javadoc.jar" "-sources.jar" ".pom"; do
+        ( cd ${JAR_DIR} && gpg -ab --passphrase ${SIGNING_PASSWORD} android-all-${ROBOLECTRIC_VERSION}$ext )
+    done
+
+    echo "Robolectric: Creating bundle for Sonatype upload..."
+    cd ${JAR_DIR}; jar cf ${ANDROID_BUNDLE} *.jar *.pom *.asc
+}
+
+mavenize() {
+    local FILE_NAME_BASE=android-all-${ROBOLECTRIC_VERSION}
+    mvn install:install-file \
+      -Dfile=${JAR_DIR}/${FILE_NAME_BASE}.jar \
+      -DgroupId=org.robolectric \
+      -DartifactId=android-all \
+      -Dversion=${ROBOLECTRIC_VERSION} \
+      -Dpackaging=jar
+
+    mvn install:install-file \
+      -Dfile=${JAR_DIR}/${FILE_NAME_BASE}-sources.jar \
+      -DgroupId=org.robolectric \
+      -DartifactId=android-all \
+      -Dversion=${ROBOLECTRIC_VERSION} \
+      -Dpackaging=jar \
+      -Dclassifier=sources
+
+    mvn install:install-file \
+      -Dfile=${JAR_DIR}/${FILE_NAME_BASE}-javadoc.jar \
+      -DgroupId=org.robolectric \
+      -DartifactId=android-all \
+      -Dversion=${ROBOLECTRIC_VERSION} \
+      -Dpackaging=jar \
+      -Dclassifier=javadoc
+}
+
+generate_empty_src_javadoc
+build_signed_packages
+mavenize
+
+echo "DONE!!"

--- a/scripts/install-dependencies.rb
+++ b/scripts/install-dependencies.rb
@@ -157,7 +157,7 @@ PLAY_SERVICES_BASEMENT = "play-services-basement"
 
 # Mavenize all dependencies
 
-install_stubs(26)
+install_stubs(27)
 
 install_aar(ANDROID_REPO, ANDROID_SUPPORT_GROUP_ID, MULTIDEX_ARTIFACT_ID, MULTIDEX_TRAILING_VERSION)
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -17,12 +17,16 @@ import android.util.TypedValue;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -34,6 +38,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
+import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.AttrData;
 import org.robolectric.res.AttributeResource;
 import org.robolectric.res.DrawableResourceLoader;
@@ -321,22 +326,37 @@ public final class ShadowAssetManager {
 
   @Implementation
   public final InputStream open(String fileName) throws IOException {
-    return getAssetsDirectory().join(fileName).getInputStream();
+    return findAssetFile(fileName).getInputStream();
   }
 
   @Implementation
   public final InputStream open(String fileName, int accessMode) throws IOException {
-    return getAssetsDirectory().join(fileName).getInputStream();
+    return findAssetFile(fileName).getInputStream();
   }
 
   @Implementation
   public final AssetFileDescriptor openFd(String fileName) throws IOException {
-    File file = new File(getAssetsDirectory().join(fileName).getPath());
+    File file = new File(findAssetFile(fileName).getPath());
     if (file.getPath().startsWith("jar")) {
       file = getFileFromZip(file);
     }
     ParcelFileDescriptor parcelFileDescriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
     return new AssetFileDescriptor(parcelFileDescriptor, 0, file.length());
+  }
+
+  private final FsFile findAssetFile(String fileName) throws IOException {
+    if (getAssetsDirectory().join(fileName).exists()) {
+      return getAssetsDirectory().join(fileName);
+    }
+
+    // otherwise look through the library assets
+    for (FsFile libraryAsset : getLibraryAssetsDirectory()) {
+      if (libraryAsset.join(fileName).exists()) {
+        return libraryAsset.join(fileName);
+      }
+    }
+
+    throw new FileNotFoundException(String.format(Locale.US, "Asset file %s not found", fileName));
   }
 
   /**
@@ -380,16 +400,21 @@ public final class ShadowAssetManager {
 
   @Implementation
   public final String[] list(String path) throws IOException {
-    FsFile file;
+    List<String> assetFiles = new ArrayList<>();
+    List<FsFile> assets = new ArrayList<>();
     if (path.isEmpty()) {
-      file = getAssetsDirectory();
+      assets.addAll(getLibraryAssetsDirectory());
     } else {
-      file = getAssetsDirectory().join(path);
+      assets.add(findAssetFile(path));
     }
-    if (file.isDirectory()) {
-      return file.listFileNames();
+
+    for (FsFile asset : assets) {
+      if (asset.isDirectory()) {
+        Collections.addAll(assetFiles, asset.listFileNames());
+      }
     }
-    return new String[0];
+
+    return assetFiles.toArray(new String[assetFiles.size()]);
   }
 
   @HiddenApi @Implementation
@@ -917,6 +942,17 @@ public final class ShadowAssetManager {
 
   private FsFile getAssetsDirectory() {
     return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory();
+  }
+
+  private List<FsFile> getLibraryAssetsDirectory() {
+    List<FsFile> libraryAssetsDirectory = new ArrayList<>();
+    for (AndroidManifest manifest : ShadowApplication.getInstance().getAppManifest().getLibraryManifests()) {
+      if (manifest.getAssetsDirectory() != null) {
+        libraryAssetsDirectory.add(manifest.getAssetsDirectory());
+      }
+    }
+
+    return libraryAssetsDirectory;
   }
 
   @Nonnull private ResName getResName(int id) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowChoreographer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowChoreographer.java
@@ -110,7 +110,7 @@ public class ShadowChoreographer {
    * AnimationHandler would result in endless looping (the execution of the task results in a new
    * animation task created and scheduled to the front of the event loop queue).
    *
-   * <p>To prevent endless looping, a test may call {@link #setPostFrameCallbackDelay(int)} to
+   * To prevent endless looping, a test may call {@link #setPostFrameCallbackDelay(int)} to
    * specify a small delay when animation is scheduled.
    *
    * @see #setPostCallbackDelay(int)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
@@ -180,7 +180,7 @@ public class ShadowDevicePolicyManager {
   /**
    * Sets the application restrictions of the {@code packageName}.
    *
-   * <p>The new {@code applicationRestrictions} always completely overwrites any existing ones.
+   * The new {@code applicationRestrictions} always completely overwrites any existing ones.
    */
   public void setApplicationRestrictions(String packageName, Bundle applicationRestrictions) {
     applicationRestrictionsMap.put(packageName, applicationRestrictions);
@@ -229,7 +229,7 @@ public class ShadowDevicePolicyManager {
   /**
    * Sets organization name.
    *
-   * <p>The API can only be called by profile owner since Android N and can be called by both of
+   * The API can only be called by profile owner since Android N and can be called by both of
    * profile owner and device owner since Android O.
    */
   @Implementation(minSdk = N)
@@ -256,11 +256,12 @@ public class ShadowDevicePolicyManager {
   /**
    * Returns organization name.
    *
-   * <p>The API can only be called by profile owner since Android N.
+   * The API can only be called by profile owner since Android N.
    *
-   * <p>Android framework has a hidden API for getting the organization name for device owner since
+   * Android framework has a hidden API for getting the organization name for device owner since
    * Android O. This method, however, is extended to return the organization name for device owners
-   * too to make testing of {@link setOrganizationName} easier for device owner cases.
+   * too to make testing of {@link #setOrganizationName(ComponentName, CharSequence)} easier for
+   * device owner cases.
    */
   @Implementation(minSdk = N)
   @Nullable
@@ -294,9 +295,9 @@ public class ShadowDevicePolicyManager {
   /**
    * Sets permitted accessibility services.
    *
-   * <p>The API can be called by either a profile or device owner.
+   * The API can be called by either a profile or device owner.
    *
-   * <p>This method does not check already enabled non-system accessibility services, so will always
+   * This method does not check already enabled non-system accessibility services, so will always
    * set the restriction and return true.
    */
   @Implementation
@@ -316,9 +317,9 @@ public class ShadowDevicePolicyManager {
   /**
    * Sets permitted input methods.
    *
-   * <p>The API can be called by either a profile or device owner.
+   * The API can be called by either a profile or device owner.
    *
-   * <p>This method does not check already enabled non-system input methods, so will always set the
+   * This method does not check already enabled non-system input methods, so will always set the
    * restriction and return true.
    */
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputMethodManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputMethodManager.java
@@ -15,7 +15,7 @@ public class ShadowInputMethodManager {
   /**
    * Handler for receiving soft input visibility changed event.
    *
-   * <p>Since Android does not have any API for retrieving soft input status, most application
+   * Since Android does not have any API for retrieving soft input status, most application
    * relies on GUI layout changes to detect the soft input change event. Currently, Robolectric are
    * not able to simulate the GUI change when application changes the soft input through {@code
    * InputMethodManager}, this handler can be used by application to simulate GUI change in response

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.KITKAT_WATCH;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.O_MR1;
 import static org.robolectric.RuntimeEnvironment.castNativePtr;
 
 import android.database.sqlite.SQLiteAbortException;
@@ -68,6 +69,12 @@ public class ShadowSQLiteConnection {
   public static Number nativeOpen(String path, int openFlags, String label, boolean enableTrace, boolean enableProfile) {
     SQLiteLibraryLoader.load();
     return castNativePtr(CONNECTIONS.open(path));
+  }
+
+  @Implementation(minSdk = O_MR1)
+  public static long nativeOpen(String path, int openFlags, String label, boolean enableTrace,
+                                boolean enableProfile, int lookasideSlotSize, int lookasideSlotCount) {
+    return nativeOpen(path, openFlags, label, enableTrace, enableProfile).longValue();
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSharedMemory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSharedMemory.java
@@ -1,0 +1,61 @@
+package org.robolectric.shadows;
+
+import android.os.Build;
+import android.os.SharedMemory;
+import android.system.ErrnoException;
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.WeakHashMap;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.util.TempDirectory;
+
+/**
+ * Shadow for {@link SharedMemory}.
+ *
+ * <p>This is not a faithful "shared" memory implementation. Since Robolectric tests only operate
+ * within a single process, this shadow just allocates an in process memory chunk.
+ */
+@Implements(value = SharedMemory.class, minSdk = Build.VERSION_CODES.O_MR1)
+public class ShadowSharedMemory {
+  private static final Map<FileDescriptor, File> filesByFd = new WeakHashMap<>();
+
+  @Implementation
+  public ByteBuffer map(int prot, int offset, int length) throws ErrnoException {
+    return ByteBuffer.allocate(length);
+  }
+
+  @Implementation
+  public static FileDescriptor nCreate(String name, int size) throws ErrnoException {
+    TempDirectory tempDirectory = RuntimeEnvironment.getTempDirectory();
+
+    try {
+      File sharedMemoryFile =
+          tempDirectory.createIfNotExists("SharedMemory").resolve("shmem-" + name).toFile();
+      RandomAccessFile randomAccessFile = new RandomAccessFile(sharedMemoryFile, "rw");
+      randomAccessFile.setLength(0);
+      randomAccessFile.setLength(size);
+      synchronized (filesByFd) {
+        filesByFd.put(randomAccessFile.getFD(), sharedMemoryFile);
+      }
+      return randomAccessFile.getFD();
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to create file descriptior", e);
+    }
+  }
+
+  @Implementation
+  public static int nGetSize(FileDescriptor fd) {
+    synchronized (filesByFd) {
+      return (int) filesByFd.get(fd).length();
+    }
+  }
+}
+
+
+

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSharedMemory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSharedMemory.java
@@ -16,15 +16,22 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.util.TempDirectory;
 
 /**
- * Shadow for {@link SharedMemory}.
- *
- * <p>This is not a faithful "shared" memory implementation. Since Robolectric tests only operate
- * within a single process, this shadow just allocates an in process memory chunk.
+ * This is not a faithful "shared" memory implementation. Since Robolectric tests only operate
+ * within a single process, this shadow just allocates an in-process memory chunk.
  */
-@Implements(value = SharedMemory.class, minSdk = Build.VERSION_CODES.O_MR1)
+@Implements(value = SharedMemory.class,
+    minSdk = Build.VERSION_CODES.O_MR1,
+    /* not quite true, but this prevents a useless `shadowOf()` accessor showing
+     * up, which would break people compiling against API 26 and earlier.
+    */
+    isInAndroidSdk = false
+)
 public class ShadowSharedMemory {
   private static final Map<FileDescriptor, File> filesByFd = new WeakHashMap<>();
 
+  /**
+   * For tests, returns a {@link ByteBuffer} of the requested size.
+   */
   @Implementation
   public ByteBuffer map(int prot, int offset, int length) throws ErrnoException {
     return ByteBuffer.allocate(length);
@@ -56,6 +63,3 @@ public class ShadowSharedMemory {
     }
   }
 }
-
-
-


### PR DESCRIPTION
### Overview
When running roboelectric tests using buck we are excluding transitive assets from the AssetManager search path which causes a lot of tests to fail. 

### Proposed Changes
The proposed fix is to also add the `libraryManifest` asset directories to the search path.