### PR TITLE
Search assets from library manifests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-thisVersion=3.5.1
+thisVersion=3.5.1-uber
 
 apiCompatVersion=3.5

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -17,12 +17,16 @@ import android.util.TypedValue;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -34,6 +38,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
+import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.AttrData;
 import org.robolectric.res.AttributeResource;
 import org.robolectric.res.DrawableResourceLoader;
@@ -321,22 +326,37 @@ public final class ShadowAssetManager {
 
   @Implementation
   public final InputStream open(String fileName) throws IOException {
-    return getAssetsDirectory().join(fileName).getInputStream();
+    return findAssetFile(fileName).getInputStream();
   }
 
   @Implementation
   public final InputStream open(String fileName, int accessMode) throws IOException {
-    return getAssetsDirectory().join(fileName).getInputStream();
+    return findAssetFile(fileName).getInputStream();
   }
 
   @Implementation
   public final AssetFileDescriptor openFd(String fileName) throws IOException {
-    File file = new File(getAssetsDirectory().join(fileName).getPath());
+    File file = new File(findAssetFile(fileName).getPath());
     if (file.getPath().startsWith("jar")) {
       file = getFileFromZip(file);
     }
     ParcelFileDescriptor parcelFileDescriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
     return new AssetFileDescriptor(parcelFileDescriptor, 0, file.length());
+  }
+
+  private final FsFile findAssetFile(String fileName) throws IOException {
+    if (getAssetsDirectory().join(fileName).exists()) {
+      return getAssetsDirectory().join(fileName);
+    }
+
+    // otherwise look through the library assets
+    for (FsFile libraryAsset : getLibraryAssetsDirectory()) {
+      if (libraryAsset.join(fileName).exists()) {
+        return libraryAsset.join(fileName);
+      }
+    }
+
+    throw new FileNotFoundException(String.format(Locale.US, "Asset file %s not found", fileName));
   }
 
   /**
@@ -380,16 +400,21 @@ public final class ShadowAssetManager {
 
   @Implementation
   public final String[] list(String path) throws IOException {
-    FsFile file;
+    List<String> assetFiles = new ArrayList<>();
+    List<FsFile> assets = new ArrayList<>();
     if (path.isEmpty()) {
-      file = getAssetsDirectory();
+      assets.addAll(getLibraryAssetsDirectory());
     } else {
-      file = getAssetsDirectory().join(path);
+      assets.add(findAssetFile(path));
     }
-    if (file.isDirectory()) {
-      return file.listFileNames();
+
+    for (FsFile asset : assets) {
+      if (asset.isDirectory()) {
+        Collections.addAll(assetFiles, asset.listFileNames());
+      }
     }
-    return new String[0];
+
+    return assetFiles.toArray(new String[assetFiles.size()]);
   }
 
   @HiddenApi @Implementation
@@ -917,6 +942,17 @@ public final class ShadowAssetManager {
 
   private FsFile getAssetsDirectory() {
     return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory();
+  }
+
+  private List<FsFile> getLibraryAssetsDirectory() {
+    List<FsFile> libraryAssetsDirectory = new ArrayList<>();
+    for (AndroidManifest manifest : ShadowApplication.getInstance().getAppManifest().getLibraryManifests()) {
+      if (manifest.getAssetsDirectory() != null) {
+        libraryAssetsDirectory.add(manifest.getAssetsDirectory());
+      }
+    }
+
+    return libraryAssetsDirectory;
   }
 
   @Nonnull private ResName getResName(int id) {


### PR DESCRIPTION
### Overview
When running roboelectric tests using buck we are excluding transitive assets from the AssetManager search path which causes a lot of tests to fail. 

### Proposed Changes
The proposed fix is to also add the `libraryManifest` asset directories to the search path.